### PR TITLE
Custom "now" time

### DIFF
--- a/src/TimelineCalendar.tsx
+++ b/src/TimelineCalendar.tsx
@@ -27,6 +27,7 @@ const TimelineCalendar: React.ForwardRefRenderFunction<
     highlightDates,
     onChange,
     editEventGestureEnabled,
+    getNow,
     ...timelineProviderProps
   },
   ref
@@ -51,6 +52,7 @@ const TimelineCalendar: React.ForwardRefRenderFunction<
     highlightDates,
     onChange,
     editEventGestureEnabled,
+    getNow
   };
 
   return (

--- a/src/components/Timeline/NowIndicator.tsx
+++ b/src/components/Timeline/NowIndicator.tsx
@@ -12,12 +12,13 @@ interface NowIndicatorProps {
   width: number;
   timeIntervalHeight: SharedValue<number>;
   nowIndicatorColor?: string;
+  getNow?: () => Date;
 }
 
 const UPDATE_TIME = 60000;
 
-const getCurrentMinutes = () => {
-  const now = new Date();
+const getCurrentMinutes = (getNow: () => Date) => {
+  const now = getNow ? getNow() : new Date();
   return now.getHours() * 60 + now.getMinutes();
 };
 
@@ -26,13 +27,14 @@ const NowIndicator = ({
   dayIndex,
   timeIntervalHeight,
   nowIndicatorColor,
+  getNow
 }: NowIndicatorProps) => {
-  const initialMinutes = useRef(getCurrentMinutes());
+  const initialMinutes = useRef(getCurrentMinutes(getNow));
   const translateY = useSharedValue(0);
   const intervalCallbackId = useRef<any>(null);
 
   const updateLinePosition = useCallback(() => {
-    const newMinutes = getCurrentMinutes();
+    const newMinutes = getCurrentMinutes(getNow);
     const subtractInitialMinutes = newMinutes - initialMinutes.current;
     const newY = (subtractInitialMinutes / 60) * timeIntervalHeight.value;
     translateY.value = withTiming(newY, {

--- a/src/components/Timeline/NowIndicator.tsx
+++ b/src/components/Timeline/NowIndicator.tsx
@@ -17,7 +17,7 @@ interface NowIndicatorProps {
 
 const UPDATE_TIME = 60000;
 
-const getCurrentMinutes = (getNow: () => Date) => {
+const getCurrentMinutes = (getNow?: () => Date) => {
   const now = getNow ? getNow() : new Date();
   return now.getHours() * 60 + now.getMinutes();
 };

--- a/src/components/Timeline/TimelinePage.tsx
+++ b/src/components/Timeline/TimelinePage.tsx
@@ -31,6 +31,7 @@ interface TimelinePageProps {
   ) => JSX.Element;
   selectedEventId?: string;
   renderCustomUnavailableItem?: (props: UnavailableItemProps) => JSX.Element;
+  getNow?: () => Date;
 }
 
 const TimelinePage = ({
@@ -46,6 +47,7 @@ const TimelinePage = ({
   renderEventContent,
   selectedEventId,
   renderCustomUnavailableItem,
+  getNow
 }: TimelinePageProps) => {
   const {
     rightSideWidth,
@@ -156,6 +158,7 @@ const TimelinePage = ({
             width={columnWidth}
             dayIndex={dayIndex}
             nowIndicatorColor={theme.nowIndicatorColor}
+            getNow={getNow}
           />
         )}
       </React.Fragment>

--- a/src/components/Timeline/TimelineSlots.tsx
+++ b/src/components/Timeline/TimelineSlots.tsx
@@ -47,6 +47,7 @@ interface TimelineSlotsProps {
   onEndDragSelectedEvent?: (event: PackedEvent) => void;
   renderCustomUnavailableItem?: (props: UnavailableItemProps) => JSX.Element;
   editEventGestureEnabled?: boolean;
+  getNow?: () => Date;
 }
 
 const TimelineSlots = ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,9 @@ export interface TimelineProps {
   onChange?: (props: OnChangeProps) => void;
 
   editEventGestureEnabled?: boolean;
+
+  /** Used in the NowIndicator to determine a custom current time **/
+  getNow?: () => Date;
 }
 
 export interface UnavailableItemProps {


### PR DESCRIPTION
First of all thank you for making this excellent library. 

I would like to propose this small addition to the code where the `NowIndicator` uses a custom "now" time. The use case for us at Sunsama is that the user can have a different timezone set than the timezone used by the device. Having the ability to change the "now" time will make it able for us to show the time indicator in the "now" the user expects to see.

I am hoping this is something you can use, if not feel free to close this PR and we will just keep using this internally.