### PR TITLE
Property `renderEventContent` not used in `DragEditItem` component

### DIFF
--- a/src/components/Timeline/DragEditItem.tsx
+++ b/src/components/Timeline/DragEditItem.tsx
@@ -8,6 +8,7 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withTiming,
+  SharedValue,
 } from 'react-native-reanimated';
 import { COLUMNS, DEFAULT_PROPS } from '../../constants';
 import { useTimelineCalendarContext } from '../../context/TimelineProvider';
@@ -18,7 +19,10 @@ import { triggerHaptic } from '../../utils';
 interface DragEditItemProps {
   selectedEvent: PackedEvent;
   onEndDragSelectedEvent?: (event: PackedEvent) => void;
-  renderEventContent?: (event: PackedEvent) => JSX.Element;
+  renderEventContent?: (
+    event: PackedEvent,
+    timeIntervalHeight: SharedValue<number>
+  ) => JSX.Element;
   isEnabled?: boolean;
 }
 
@@ -268,7 +272,7 @@ const DragEditItem = ({
           ]}
         >
           {renderEventContent
-            ? renderEventContent(event)
+            ? renderEventContent(event, timeIntervalHeight)
             : _renderEventContent()}
           <GestureDetector gesture={dragDurationGesture}>
             <View style={[styles.indicator, { width: columnWidth }]}>

--- a/src/components/Timeline/TimelineSlots.tsx
+++ b/src/components/Timeline/TimelineSlots.tsx
@@ -59,6 +59,7 @@ const TimelineSlots = ({
   selectedEvent,
   onEndDragSelectedEvent,
   editEventGestureEnabled = true,
+  renderEventContent,
   ...other
 }: TimelineSlotsProps) => {
   const {
@@ -137,6 +138,7 @@ const TimelineSlots = ({
         holidays={extraData?.holidays}
         events={extraData?.events}
         selectedEventId={extraData?.selectedEventId}
+        renderEventContent={renderEventContent}
         {...other}
       />
     );
@@ -253,6 +255,7 @@ const TimelineSlots = ({
             selectedEvent={selectedEvent}
             onEndDragSelectedEvent={onEndDragSelectedEvent}
             isEnabled={editEventGestureEnabled}
+            renderEventContent={renderEventContent}
           />
         )}
       </ScrollView>


### PR DESCRIPTION
Currently the `renderEventContent` is declared in the `DragEditItem` but never passed into, so in effect it never works. This patch passes that property in properly.