### PR TITLE
Theme `editIndicatorColor` not used

### DIFF
--- a/src/components/Timeline/DragEditItem.tsx
+++ b/src/components/Timeline/DragEditItem.tsx
@@ -272,8 +272,22 @@ const DragEditItem = ({
             : _renderEventContent()}
           <GestureDetector gesture={dragDurationGesture}>
             <View style={[styles.indicator, { width: columnWidth }]}>
-              <View style={styles.indicatorLine} />
-              <View style={styles.indicatorLine} />
+              <View
+                style={[
+                  styles.indicatorLine,
+                  theme.editIndicatorColor
+                    ? { backgroundColor: theme.editIndicatorColor }
+                    : undefined,
+                ]}
+              />
+              <View
+                style={[
+                  styles.indicatorLine,
+                  theme.editIndicatorColor
+                    ? { backgroundColor: theme.editIndicatorColor }
+                    : undefined,
+                ]}
+              />
             </View>
           </GestureDetector>
         </Animated.View>


### PR DESCRIPTION
I'm going to assume that `editIndicatorColor` is used for this specific view, so I've added it in there since currently you cannot change the drag-indicator colour and also the property isn't used.