### PR TITLE
feat: allow for setting minimum event height

### DIFF
--- a/src/components/Timeline/EventBlock.tsx
+++ b/src/components/Timeline/EventBlock.tsx
@@ -59,11 +59,17 @@ const EventBlock = ({
   };
 
   const eventStyle = useAnimatedStyle(() => {
+    let eventHeight = event.duration * timeIntervalHeight.value;
+
+    if (theme.minimumEventHeight) {
+      eventHeight = Math.max(theme.minimumEventHeight, eventHeight);
+    }
+
     return {
       top: withTiming(event.startHour * timeIntervalHeight.value, {
         duration: eventAnimatedDuration,
       }),
-      height: withTiming(event.duration * timeIntervalHeight.value, {
+      height: withTiming(eventHeight, {
         duration: eventAnimatedDuration,
       }),
       left: withTiming(event.left + columnWidth * dayIndex, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,6 +199,7 @@ export interface ThemeProperties {
 
   //Event
   eventTitle?: TextStyle;
+  minimumEventHeight?: number;
 }
 
 export interface RangeTime {


### PR DESCRIPTION
When you have a very short event, like 5 or 15 minutes the element is so small you can't see it, and sometimes, interact with it.

This PR introduces a minimum height theme property to make sure the `EventBlock` is always at least X high.