### PR TITLE
feat: add getHour and getDate methods on Timeline

### DIFF
--- a/src/components/Timeline/index.tsx
+++ b/src/components/Timeline/index.tsx
@@ -116,6 +116,23 @@ const Timeline: React.ForwardRefRenderFunction<
       goToPrevPage: goToPrevPage,
       getZones: () => Object.values(timeZoneData),
       getZone: (key: keyof typeof timeZoneData) => timeZoneData[key],
+      getHour: () => {
+        const position = offsetY.value + 8;
+        const minutes =
+          ((position - spaceFromTop) * 60) / timeIntervalHeight.value;
+        const hour = minutes / 60;
+        return Math.max(0, hour);
+      },
+      getDate: () => {
+        const numOfDays =
+          viewMode === 'workWeek' ? COLUMNS.week : COLUMNS[viewMode];
+        const firstDateMoment = dayjs(firstDate.current[viewMode]);
+        const pageIndex = currentIndex.value;
+        const currentDay = firstDateMoment
+          .add(pageIndex * numOfDays, 'd')
+          .add(tzOffset, 'm');
+        return currentDay.toISOString();
+      },
       goToHour: (hour: number, animated?: boolean) => {
         const minutes = hour * 60;
         const position =
@@ -151,6 +168,7 @@ const Timeline: React.ForwardRefRenderFunction<
       totalPages,
       timelineHorizontalListRef,
       timeIntervalHeight,
+      currentIndex.value,
       spaceFromTop,
       goToOffsetY,
       minTimeIntervalHeight.value,

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export interface TimelineCalendarHandle {
     raw: string;
     countryName: string;
   };
+  getHour: () => number;
+  getDate: () => string;
   goToHour: (hour: number, animated?: boolean) => void;
   forceUpdateNowIndicator: (customDate?: string) => void;
   /**


### PR DESCRIPTION
Motivation: Being able to destroy the timeline component and recreate it with the correct date and hour position for seamless experience.