### PR TITLE
Allow for an onChange event for when the `timeIntervalHeight` value changes

### DIFF
--- a/src/context/TimelineProvider.tsx
+++ b/src/context/TimelineProvider.tsx
@@ -41,6 +41,7 @@ type CustomTimelineProviderProps = Required<
     | 'hourFormat'
     | 'timeZone'
     | 'calendarWidth'
+    | 'onTimeIntervalHeightChange'
   >
 >;
 

--- a/src/context/TimelineProvider.tsx
+++ b/src/context/TimelineProvider.tsx
@@ -11,6 +11,7 @@ import React, {
 import { PixelRatio, ScrollView, useWindowDimensions } from 'react-native';
 import type { GestureType } from 'react-native-gesture-handler';
 import {
+  runOnJS,
   SharedValue,
   useDerivedValue,
   useSharedValue,
@@ -100,6 +101,7 @@ const TimelineProvider: React.FC<TimelineProviderProps> = (props) => {
     initialTimeIntervalHeight = DEFAULT_PROPS.INIT_TIME_INTERVAL_HEIGHT,
     minTimeIntervalHeight: initialMinTimeIntervalHeight,
     maxTimeIntervalHeight = DEFAULT_PROPS.MAX_TIME_INTERVAL_HEIGHT,
+    onTimeIntervalHeightChange,
     syncedLists = true,
     theme: initTheme,
     spaceFromTop = DEFAULT_PROPS.SPACE_CONTENT,
@@ -178,6 +180,18 @@ const TimelineProvider: React.FC<TimelineProviderProps> = (props) => {
     initialMinTimeIntervalHeight || 0
   );
   const isDragCreateActive = useSharedValue(false);
+
+  const hasOnTimeIntervalHeightChange = !!onTimeIntervalHeightChange;
+
+  useDerivedValue(() => {
+    if (hasOnTimeIntervalHeightChange) {
+      runOnJS(onTimeIntervalHeightChange)(timeIntervalHeight.value);
+    }
+  }, [
+    hasOnTimeIntervalHeightChange,
+    onTimeIntervalHeightChange,
+    timeIntervalHeight,
+  ]);
 
   const offsetY = useSharedValue(0);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,6 +195,9 @@ export interface TimelineProviderProps {
    */
   maxTimeIntervalHeight?: number;
 
+  /** Callback function will be called when time interval height changed */
+  onTimeIntervalHeightChange?: (height: number) => void;
+
   /** Auto scroll header when scroll time slots view.
    *
    ** Default: `true`


### PR DESCRIPTION
Currently you can set a min, max and initial value for the `timeIntervalHeight` but there is no way of saving the value when the user zooms the calendar. This will allow for listening to the value so we can save it.