### PR TITLE
Minimum event height isn't honoured when editing an event

### DIFF
--- a/src/components/Timeline/DragEditItem.tsx
+++ b/src/components/Timeline/DragEditItem.tsx
@@ -76,7 +76,11 @@ const DragEditItem = ({
   const startXY = useSharedValue({ x: 0, y: 0 });
   const translateX = useSharedValue(0);
   const eventTop = useSharedValue(defaultTopPosition);
-  const eventHeight = useSharedValue<number>(event.height);
+  const eventHeight = useSharedValue<number>(
+    theme.minimumEventHeight
+      ? Math.max(theme.minimumEventHeight, event.height)
+      : event.height
+  );
 
   useEffect(() => {
     if (useHaptic) {
@@ -266,7 +270,12 @@ const DragEditItem = ({
       const nextHeight = startHeight.value + e.translationY;
       const roundedHeight =
         Math.ceil(nextHeight / heightOfTenMinutes) * heightOfTenMinutes;
-      const clampedHeight = Math.max(roundedHeight, heightOfTenMinutes);
+      const clampedHeight = theme.minimumEventHeight
+        ? Math.max(
+            theme.minimumEventHeight,
+            Math.max(roundedHeight, heightOfTenMinutes)
+          )
+        : Math.max(roundedHeight, heightOfTenMinutes);
       const isSameHeight = eventHeight.value === clampedHeight;
       if (!isSameHeight) {
         eventHeight.value = clampedHeight;


### PR DESCRIPTION
To make sure the minimumEventHeight is also obeyed when editing an event.

It has one caveat which I'd like to see fixed as well (which I will do) and that is that the minimum event duration is now dependent on the smallest size the element can get. Ideally the duration would be able to go smaller (e.g. to 5 minutes) while the event stays the minimum height.

@howljs what do you think?