### PR TITLE
fix: the event is positioned incorrectly

### DIFF
--- a/src/components/EventItem.tsx
+++ b/src/components/EventItem.tsx
@@ -116,7 +116,7 @@ const EventItem: FC<EventItemProps> = ({
 
   const eventPosX = useDerivedValue(() => {
     let left = data.diffDays * columnWidthAnim.value;
-    left += (eventWidth.value + overlapEventsSpacing) * index;
+    left += (eventWidth.value + overlapEventsSpacing) * (index / columnSpan);
     return withTiming(left, { duration: 150 });
   }, [data.diffDays, overlapEventsSpacing, rightEdgeSpacing, index, total]);
 


### PR DESCRIPTION
Bug:

<img width="109" alt="Screenshot 2024-09-24 at 17 04 07" src="https://github.com/user-attachments/assets/acf7fead-9537-440e-8065-380fa61559c8">

Expect:
<img width="100" alt="Screenshot 2024-09-24 at 17 02 57" src="https://github.com/user-attachments/assets/858ca690-e450-46d0-b9a4-6341da9ad7d8">
