### PR TITLE
Determines how events that overlap in time are displayed

### DIFF
--- a/src/CalendarContainer.tsx
+++ b/src/CalendarContainer.tsx
@@ -121,6 +121,8 @@ const CalendarContainer: React.ForwardRefRenderFunction<
     overlapEventsSpacing = 1,
     minRegularEventMinutes = 1,
     onLoad,
+    overlapType,
+    minStartDifference,
   },
   ref
 ) => {
@@ -498,9 +500,18 @@ const CalendarContainer: React.ForwardRefRenderFunction<
       const eventsByDate = eventsRef.current?.getEventsByDate(dateString) ?? [];
       for (let i = 0; i < eventsByDate.length; i++) {
         const event = eventsByDate[i]!;
-        const { total, index } = event._internal;
-        const eventWidth = columnWidth / total;
-        const eventX = index * eventWidth;
+        let eventX = 0,
+          eventWidth = 0;
+        const { total, index, xOffsetPercentage, widthPercentage } =
+          event._internal;
+        if (xOffsetPercentage && widthPercentage) {
+          eventWidth = columnWidth * widthPercentage;
+          eventX = columnWidth * xOffsetPercentage;
+        } else if (total && index) {
+          eventWidth = columnWidth / total;
+          eventX = index * eventWidth;
+        }
+
         const targetX = position.x - columnIndex * columnWidth;
         if (targetX >= eventX && targetX <= eventX + eventWidth) {
           let clonedEvent = { ...event } as EventItem;
@@ -706,6 +717,8 @@ const CalendarContainer: React.ForwardRefRenderFunction<
                           pagesPerSide={pagesPerSide}
                           minRegularEventMinutes={minRegularEventMinutes}
                           hideWeekDays={hideWeekDays}
+                          overlapType={overlapType}
+                          minStartDifference={minStartDifference}
                         >
                           <DragEventProvider
                             dragStep={dragStep}

--- a/src/components/DraggableEvent.tsx
+++ b/src/components/DraggableEvent.tsx
@@ -130,6 +130,7 @@ export const DraggableEvent: FC<DraggableEventProps> = ({
         <View
           style={[
             StyleSheet.absoluteFill,
+            theme.eventContainerStyle,
             styles.event,
             {
               backgroundColor:
@@ -139,7 +140,6 @@ export const DraggableEvent: FC<DraggableEventProps> = ({
                   : 'transparent'),
               borderColor: theme.primaryColor,
             },
-            theme.eventContainerStyle,
             containerStyle,
           ]}
         >

--- a/src/components/DraggingEvent.tsx
+++ b/src/components/DraggingEvent.tsx
@@ -120,12 +120,12 @@ export const DraggingEvent: FC<DraggingEventProps> = ({
       <View
         style={[
           StyleSheet.absoluteFill,
+          theme.eventContainerStyle,
           styles.event,
           {
             backgroundColor: draggingEvent?.color ?? 'transparent',
             borderColor: theme.primaryColor,
           },
-          theme.eventContainerStyle,
           containerStyle,
         ]}
       >

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -63,3 +63,5 @@ export const DEBOUNCE_TIME = 200;
 export const MIN_ALL_DAY_MINUTES = 20;
 export const MAX_ALL_DAY_MINUTES = 30;
 export const DEFAULT_ALL_DAY_MINUTES = 20;
+
+export const DEFAULT_MIN_START_DIFFERENCE = 30;

--- a/src/context/EventsProvider.tsx
+++ b/src/context/EventsProvider.tsx
@@ -8,7 +8,10 @@ import React, {
   useImperativeHandle,
   type PropsWithChildren,
 } from 'react';
-import { MILLISECONDS_IN_DAY } from '../constants';
+import {
+  DEFAULT_MIN_START_DIFFERENCE,
+  MILLISECONDS_IN_DAY,
+} from '../constants';
 import useLazyRef from '../hooks/useLazyRef';
 import { useSyncExternalStoreWithSelector } from '../hooks/useSyncExternalStoreWithSelector';
 import { createStore, type Store } from '../storeBuilder';
@@ -50,6 +53,8 @@ interface EventsProviderProps {
   hideWeekDays: WeekdayNumbers[];
   defaultOffset?: number;
   minRegularEventMinutes?: number;
+  overlapType?: 'no-overlap' | 'overlap';
+  minStartDifference?: number;
 }
 
 export interface EventsRef {
@@ -70,6 +75,8 @@ const EventsProvider: ForwardRefRenderFunction<
     hideWeekDays,
     defaultOffset = 7,
     minRegularEventMinutes = 1,
+    overlapType = 'no-overlap',
+    minStartDifference = DEFAULT_MIN_START_DIFFERENCE,
   },
   ref
 ) => {
@@ -120,7 +127,10 @@ const EventsProvider: ForwardRefRenderFunction<
       });
       const packedRegularEvents: Record<string, PackedEvent[]> = {};
       regularEventMap.forEach((rEvents, day) => {
-        packedRegularEvents[day] = populateEvents(rEvents);
+        packedRegularEvents[day] = populateEvents(rEvents, {
+          overlap: overlapType === 'overlap',
+          minStartDifference,
+        });
       });
 
       // Process all-day events
@@ -168,6 +178,8 @@ const EventsProvider: ForwardRefRenderFunction<
       pagesPerSide,
       showAllDay,
       timeZone,
+      overlapType,
+      minStartDifference,
     ]
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -529,6 +529,25 @@ export interface CalendarProviderProps extends ActionsProviderProps {
    * Default is `30` minutes
    */
   defaultDuration?: number;
+
+  /**
+   * Determines how events that overlap in time are displayed.
+   *
+   * - 'no-overlap': Events will be displayed side by side without overlapping.
+   * - 'overlap': Events will be displayed on top of each other, potentially overlapping.
+   *
+   * Default is `no-overlap`
+   */
+  overlapType?: 'no-overlap' | 'overlap';
+
+  /**
+   * Minimum start time difference (in minutes) between overlapping events.
+   * Events with start times closer than this value will be considered overlapping.
+   * This affects how events are positioned and displayed when using 'overlap' overlapType.
+   *
+   * Default is `30` minutes
+   */
+  minStartDifference?: number;
 }
 
 export interface EventItem extends Record<string, any> {
@@ -771,15 +790,35 @@ export interface EventItemInternal extends EventItem {
     endUnix: number;
     duration: number;
     startMinutes?: number;
-    index: number;
     weekStart?: number;
+  };
+}
+
+export interface NoOverlapEvent extends EventItemInternal {
+  _internal: EventItemInternal['_internal'] & {
+    index?: number;
+  };
+}
+
+export interface OverlapEvent extends EventItemInternal {
+  _internal: EventItemInternal['_internal'] & {
+    container?: OverlapEvent;
+    row?: OverlapEvent;
+    rows?: OverlapEvent[];
+    leaves?: OverlapEvent[];
+    _width?: number;
+    width?: number;
+    xOffset?: number;
   };
 }
 
 export interface PackedEvent extends EventItemInternal {
   _internal: EventItemInternal['_internal'] & {
-    total: number;
-    columnSpan: number;
+    total?: number;
+    columnSpan?: number;
+    widthPercentage?: number;
+    xOffsetPercentage?: number;
+    index?: number;
   };
 }
 


### PR DESCRIPTION
FEAT: Determines how events that overlap in time are displayed #69

<img width="451" alt="Screenshot 2024-09-27 at 17 59 28" src="https://github.com/user-attachments/assets/6e511d79-2d1e-441f-b99f-46bfc9c3c30d">


![Simulator Screenshot - iPhone 16 Pro Max - 2024-09-27 at 17 58 26](https://github.com/user-attachments/assets/28b7db04-8e36-4781-9fe1-88aa556e098e)
