### PR TITLE
feat: add titleColor property to event rendering

### DIFF
--- a/packages/react-native-calendar-kit/src/components/EventItem.tsx
+++ b/packages/react-native-calendar-kit/src/components/EventItem.tsx
@@ -239,7 +239,12 @@ const EventItem: FC<EventItemProps> = ({
               height: eventHeight,
             })
           ) : (
-            <Text style={[{color: event.titleColor},styles.title, theme.eventTitleStyle]}>
+            <Text
+              style={[
+                styles.title,
+                theme.eventTitleStyle,
+                { color: event.titleColor },
+              ]}>
               {event.title}
             </Text>
           )}

--- a/packages/react-native-calendar-kit/src/components/EventItem.tsx
+++ b/packages/react-native-calendar-kit/src/components/EventItem.tsx
@@ -16,8 +16,8 @@ import { MILLISECONDS_IN_DAY } from '../constants';
 import { useBody } from '../context/BodyContext';
 import { useTheme } from '../context/ThemeProvider';
 import type { OnEventResponse, PackedEvent, SizeAnimation } from '../types';
-import Text from './Text';
 import { parseDateTime } from '../utils/dateUtils';
+import Text from './Text';
 
 interface EventItemProps {
   event: PackedEvent;
@@ -239,7 +239,7 @@ const EventItem: FC<EventItemProps> = ({
               height: eventHeight,
             })
           ) : (
-            <Text style={[styles.title, theme.eventTitleStyle]}>
+            <Text style={[{color: event.titleColor},styles.title, theme.eventTitleStyle]}>
               {event.title}
             </Text>
           )}

--- a/packages/react-native-calendar-kit/src/components/MultiDayBarItem.tsx
+++ b/packages/react-native-calendar-kit/src/components/MultiDayBarItem.tsx
@@ -326,7 +326,14 @@ const EventItem = ({
             height: eventHeight,
           })
         ) : (
-          <Text style={[styles.eventTitle, rest.titleStyle]}>{rest.title}</Text>
+          <Text
+            style={[
+              styles.eventTitle,
+              rest.titleStyle,
+              { color: rest.titleColor },
+            ]}>
+            {rest.title}
+          </Text>
         )}
       </TouchableOpacity>
     </Animated.View>

--- a/packages/react-native-calendar-kit/src/components/SingleDayBarItem.tsx
+++ b/packages/react-native-calendar-kit/src/components/SingleDayBarItem.tsx
@@ -260,7 +260,14 @@ const EventItem = ({
             height: eventHeight,
           })
         ) : (
-          <Text style={[styles.eventTitle, rest.titleStyle]}>{rest.title}</Text>
+          <Text
+            style={[
+              styles.eventTitle,
+              rest.titleStyle,
+              { color: rest.titleColor },
+            ]}>
+            {rest.title}
+          </Text>
         )}
       </TouchableOpacity>
     </Animated.View>

--- a/packages/react-native-calendar-kit/src/types.ts
+++ b/packages/react-native-calendar-kit/src/types.ts
@@ -580,6 +580,9 @@ export interface EventItem extends Record<string, any> {
   /** Background color of the event */
   color?: string;
 
+  /** Title color of the event */
+  titleColor?: string;
+
   /** Recurrence rule for the event. */
   recurrence?: string;
 


### PR DESCRIPTION
This PR introduces the titleColor property to the EventItem in react-native-calendar-kit, allowing developers to customize the color of individual event titles directly.

### Why This Change?
Previously, the event title color could only be customized globally via theme.eventTitleStyle. While this works for consistent styles, it lacked the flexibility to dynamically set different colors for individual events.

By introducing the titleColor property:

Developers can assign unique title colors for specific events.
The fallback to theme.eventTitleStyle ensures backward compatibility and consistent behavior for events without titleColor.