### PR TITLE
fix: all-day events calculation

### DIFF
--- a/packages/react-native-calendar-kit/src/utils/eventUtils.ts
+++ b/packages/react-native-calendar-kit/src/utils/eventUtils.ts
@@ -231,8 +231,11 @@ export const divideAllDayEvents = (
   ).toMillis();
   const weekEndUnix = startOfWeek(eventEnd.toISODate(), firstDay).toMillis();
 
+  const startWeekNumber = Math.floor(weekStartUnix / (7 * MILLISECONDS_IN_DAY));
+  const endWeekNumber = Math.floor(weekEndUnix / (7 * MILLISECONDS_IN_DAY));
   const diffWeeks =
-    Math.floor((weekEndUnix - weekStartUnix) / (7 * MILLISECONDS_IN_DAY)) + 1;
+    startWeekNumber === endWeekNumber ? 1 : endWeekNumber - startWeekNumber + 1;
+    
   const isSameDay = event._internal.startUnix === event._internal.endUnix;
   let eventStartUnix = eventStart.startOf('day').toMillis();
   const eventEndUnix = isSameDay


### PR DESCRIPTION
# Improve all-day events calculation  

## Problem  
When creating an all-day event that spans multiple months, the calendar does not correctly divide the event.  

For example, an event starting on **March 28, 2025**, and ending on **April 2, 2025**, currently only appears from **March 28 to March 30**. However, it should also create a continuation from **March 31 to April 2**.  

### Behavior Comparison  

| ❌ Current Behavior | ✅ Expected Behavior |
|---------------------|---------------------|
| ![Incorrect](https://github.com/user-attachments/assets/a91ac785-3099-46e0-89a8-d7bbff08a865) | ![Correct](https://github.com/user-attachments/assets/bcba3228-2761-4df5-aa9a-73befea2051e) |

## Solution  
Added a check to determine whether the event spans multiple weeks. If the start and end weeks differ, an additional event segment is created to ensure proper display across month boundaries.
