### PR TITLE
fix Indicator partially cut off on Android

### DIFF
--- a/packages/react-native-calendar-kit/src/components/TimeColumn.tsx
+++ b/packages/react-native-calendar-kit/src/components/TimeColumn.tsx
@@ -135,7 +135,7 @@ const HourWrapper: React.FC<PropsWithChildren<HourWrapperProps>> = ({
 };
 
 const styles = StyleSheet.create({
-  container: { zIndex: 998 },
+  container: { zIndex: 998, elevation: -1 },
   absolute: { position: 'absolute' },
   rightLine: {
     position: 'absolute',


### PR DESCRIPTION
So apparently Android sometimes does not correctly handle `zIndex`. 

With a workaround from https://github.com/facebook/react-native/issues/35565 the (custom) indicator is fully visible again and on the correct zIndex.

Before: 
<img width="110" alt="image" src="https://github.com/user-attachments/assets/7c029435-39e3-468d-9796-ef217095e7b2" />

After: 
<img width="137" alt="image" src="https://github.com/user-attachments/assets/e146018f-fb2b-4cf9-b639-c475593c4da3" />

--- 

With custom indicator it is even more visible: 

Before:
<img width="465" alt="Bildschirmfoto 2025-03-30 um 12 35 35" src="https://github.com/user-attachments/assets/8d906033-3759-4e1e-8f8e-50808b10e643" />

After:
<img width="458" alt="Bildschirmfoto 2025-03-30 um 12 35 27" src="https://github.com/user-attachments/assets/6a43fd7f-ae22-440e-b63a-786173d549b9" />
