### PR TITLE
fix: unavailable hours are not displayed properly when forcing timezone

### DIFF
--- a/packages/react-native-calendar-kit/src/context/UnavailableHoursProvider.tsx
+++ b/packages/react-native-calendar-kit/src/context/UnavailableHoursProvider.tsx
@@ -56,10 +56,10 @@ const UnavailableHoursProvider: FC<
 
       const data: Record<string, UnavailableHourProps[]> = {};
       // Iterate over the date range
-      let startDateTime = parseDateTime(date).minus({
+      let startDateTime = parseDateTime(date, {zone: timeZone}).minus({
         days: offset * pagesPerSide,
       });
-      const endDateTime = parseDateTime(date).plus({
+      const endDateTime = parseDateTime(date, {zone: timeZone}).plus({
         days: offset * (pagesPerSide + 1),
       });
 


### PR DESCRIPTION
Unavailable Hours are not displayed properly when setting custom TimeZone

close #202 